### PR TITLE
Polishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,3 +62,7 @@ dependencies {
 	testImplementation loggers
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
 }
+
+test {
+	useJUnitPlatform()
+}

--- a/docs/tcp-client.puml
+++ b/docs/tcp-client.puml
@@ -1,70 +1,107 @@
 @startuml
 
-class java.net.Socket {}
-
-class org.apache.commons.pool2.impl.GenericObjectPool {}
+skinparam ClassAttributeIconSize 0
 
 package tcp {
-    interface TcpClient {
-        ' create Socket before writing
-        + write(message: byte[]): void
-        ' dispose Socket after reading
-        + read(): byte[]
+    package client {
+        interface TcpClient {
+            + void write(byte[] message)
+            + byte[] read()
+        }
+
+        abstract AbstractTcpClient implements TcpClient {
+            # int connectionTimeout
+            # int readTimeout
+            # Charset charset
+
+            + {abstract} void write(byte[] message)
+            + {abstract} byte[] read()
+            # Socket createSocket(String host, int port, int connectionTimeout, int readTimeout)
+        }
+
+        class DisposableTcpClient extends AbstractTcpClient {
+            - Socket socket
+            + void write(byte[] message)
+            + byte[] read()
+        }
+
+        class PooledTcpClient extends AbstractTcpClient {
+            - ObjectPool<Tuple> pool
+            + void write(byte[] message)
+            + byte[] read()
+        }
     }
 
-    class DisposableTcpClient implements TcpClient {
+    package visitor {
+        interface Formattable {
+            + void accept(Formatter formatter)
+        }
+
+        interface Formatter {
+            + void format(Packet formattable)
+        }
+
+        interface Parseable {
+            + void accept(Parser parser)
+        }
+
+        interface Parser {
+            + void parse(Packet parseable)
+        }
+
+        Parseable -[hidden]left-> Parser
     }
 
-    class PooledTcpClient implements TcpClient {
-        - pool: GenericObjectPool<Socket>
+    package tcpExample {
+        class FixedByteFormatter implements Formatter {
+            + void format(Packet formattable)
+        }
+        class FiexedByteParser implements Parser {
+            + void parse(Packet parseable)
+        }
     }
 
-    DisposableTcpClient ----> java.net.Socket
-    PooledTcpClient ----> java.net.Socket
-    PooledTcpClient -----> org.apache.commons.pool2.impl.GenericObjectPool
+    Packet -[hidden]down-> TcpMessage
 
-    ' Parsing & Formatting: Visitor Pattern
-    interface Parceable <<visitable>> {
-        + accept(parser: Parser): void
+    interface TcpMessage {
+        + String getName()
+        + void setName(String name)
+        + int getPointer()
+        + String getValue()
+        + void setValue(String value)
     }
-
-    interface Formattable <<visitable>> {
-        + accept(formatter: Formatter): void
-    }
-
-    interface Parser <<visitor>> {
-        + parse(parseable: Packet): void
-    }
-
-    interface Formatter <<visitor>> {
-        + format(formattable: Packet): void
-    }
-
-    ' Tcp Message: Composite Pattern
-    interface TcpMessage <<component>> {
-        + getName(): String
-        + setName(name: String): void
-        + getPoiner(): int
-        + getValue(): String
-        + setValue(value: String)
-    }
-
-    class Packet <<composite>> implements Parceable, Formattable, TcpMessage {
-        - messageComponents: List<TcpMessage>
-        - tcpMessage: byte[]
-    }
-
-    class Item <<leaf>> implements TcpMessage {}
 
     interface TcpMessageTemplateFactory {
-        + create(tcpMessage: byte[]): List<TcpMessage>
+        + List<TcpMessage> create(byte[] tcpMessage)
     }
 
-    Packet o-down-> TcpMessage
-    Parceable -down-> Parser
-    Formattable -down-> Formatter
-    Parser -down-> Packet
-    Formatter -down-> Packet
+    class Packet implements Parseable, Formattable, TcpMessage {
+        - List<TcpMessage> messageComponents
+        + void accept(Parser parser)
+        + void accept(Formatter formatter)
+        + void add(TcpMessage component)
+    }
+
+    class Item implements TcpMessage {
+    }
+
+    Packet ..> Parser
+    Packet ..> Formatter
+    Packet "1"-down->"n" TcpMessage
 }
+
+package org.apache.commons.pool2.impl {
+    class GenericObjectPool<Socket>
+}
+
+package java.net {
+    class Socket
+}
+
+DisposableTcpClient -down-> Socket
+PooledTcpClient --down--> GenericObjectPool
+GenericObjectPool -down-> Socket
+
+FixedByteFormatter -[hidden]down-> TcpMessageTemplateFactory
 
 @enduml

--- a/docs/tcp-client.puml
+++ b/docs/tcp-client.puml
@@ -12,7 +12,6 @@ package tcp {
         abstract AbstractTcpClient implements TcpClient {
             # int connectionTimeout
             # int readTimeout
-            # Charset charset
 
             + {abstract} void write(byte[] message)
             + {abstract} byte[] read()
@@ -50,15 +49,15 @@ package tcp {
         }
 
         Parseable -[hidden]left-> Parser
-    }
 
-    package tcpExample {
-        class FixedByteFormatter implements Formatter {
-            + void format(Packet formattable)
-        }
-        class FiexedByteParser implements Parser {
-            + void parse(Packet parseable)
-        }
+        package example {
+                class FixedByteFormatter implements Formatter {
+                    + void format(Packet formattable)
+                }
+                class FiexedByteParser implements Parser {
+                    + void parse(Packet parseable)
+                }
+            }
     }
 
     Packet -[hidden]down-> TcpMessage

--- a/docs/tcp-server.puml
+++ b/docs/tcp-server.puml
@@ -1,17 +1,28 @@
 @startuml
 
-class TcpServerProperties {
-  - port: int
-  - maxConnection: int
+skinparam ClassAttributeIconSize 0
+
+package server {
+  abstract class AbstractTcpServer {
+    # int port
+    + {abstract} void handleMessage(InputStream reader, OutputStream writer)
+    + void start()
+    + void stop()
+  }
+
+  package example {
+    class EchoServer extends AbstractTcpServer {
+        + void handleMessage(InputStream reader, OutputStream writer)
+     }
+  }
 }
 
-class SettleTcpServer {
-  - port: int
-  - executor: ExecutorService
-  + start(): void
-  + stop(): void
+package java.net {
+  class ServerSocket
+  class Socket
 }
 
-SettleTcpServer -> TcpServerProperties
+AbstractTcpServer ..> ServerSocket
+AbstractTcpServer ..> Socket
 
 @enduml

--- a/src/main/java/com/vroong/tcp/Packet.java
+++ b/src/main/java/com/vroong/tcp/Packet.java
@@ -4,7 +4,7 @@ import static java.util.function.Function.identity;
 
 import com.vroong.tcp.visitor.Formattable;
 import com.vroong.tcp.visitor.Formatter;
-import com.vroong.tcp.visitor.Parceable;
+import com.vroong.tcp.visitor.Parseable;
 import com.vroong.tcp.visitor.Parser;
 import java.util.ArrayList;
 import java.util.List;
@@ -19,7 +19,7 @@ import lombok.ToString;
 @Setter
 @EqualsAndHashCode
 @ToString(of = {"messageComponents"})
-public class Packet implements Parceable, Formattable, TcpMessage {
+public class Packet implements Parseable, Formattable, TcpMessage {
 
   private List<TcpMessage> messageComponents = new ArrayList<>();
 

--- a/src/main/java/com/vroong/tcp/TcpUtils.java
+++ b/src/main/java/com/vroong/tcp/TcpUtils.java
@@ -1,0 +1,40 @@
+package com.vroong.tcp;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+public class TcpUtils {
+
+  static final int EOF = -1;
+
+  public static boolean containsNewLine(byte[] haystack) {
+    byte[] needle = new byte[]{ 10 };
+    for (int i = 0; i <= haystack.length - needle.length; i++) {
+      int j = 0;
+      while (j < needle.length && haystack[i + j] == needle[j]) {
+        j++;
+      }
+      if (j == needle.length) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public static byte[] readLine(InputStream reader) throws IOException {
+    byte[] buffer = new byte[8192]; // InputStream DEFAULT_BUFFER_SIZE
+    int totalSize = 0;
+    int currentSize = 0;
+
+    while (EOF != (currentSize = reader.read(buffer))) {
+      totalSize += currentSize;
+      if (containsNewLine(buffer)) {
+        totalSize -= 1; // "\n" size 제외
+        break;
+      }
+    }
+
+    return Arrays.copyOfRange(buffer, 0, totalSize); // byte array padding 제거
+  }
+}

--- a/src/main/java/com/vroong/tcp/TcpUtils.java
+++ b/src/main/java/com/vroong/tcp/TcpUtils.java
@@ -1,5 +1,6 @@
 package com.vroong.tcp;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -24,17 +25,17 @@ public class TcpUtils {
 
   public static byte[] readLine(InputStream reader) throws IOException {
     byte[] buffer = new byte[8192]; // InputStream DEFAULT_BUFFER_SIZE
-    int totalSize = 0;
-    int currentSize = 0;
+    int receivedSize = 0;
 
-    while (EOF != (currentSize = reader.read(buffer))) {
-      totalSize += currentSize;
+    final ByteArrayOutputStream received = new ByteArrayOutputStream();
+    while (EOF != (receivedSize = reader.read(buffer))) {
+      received.write(buffer, 0, receivedSize);
+
       if (containsNewLine(buffer)) {
-        totalSize -= 1; // "\n" size 제외
-        break;
+        return Arrays.copyOf(received.toByteArray(), received.size() - 1); // "\n" size 제외
       }
     }
 
-    return Arrays.copyOfRange(buffer, 0, totalSize); // byte array padding 제거
+    return received.toByteArray();
   }
 }

--- a/src/main/java/com/vroong/tcp/client/AbstractTcpClient.java
+++ b/src/main/java/com/vroong/tcp/client/AbstractTcpClient.java
@@ -3,7 +3,6 @@ package com.vroong.tcp.client;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import java.nio.charset.Charset;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -15,9 +14,6 @@ public abstract class AbstractTcpClient implements TcpClient {
 
   @Setter
   protected int readTimeout = 5_000;
-
-  @Setter
-  protected Charset charset;
 
   @Override
   public abstract void write(byte[] message) throws Exception;

--- a/src/main/java/com/vroong/tcp/client/DisposableTcpClient.java
+++ b/src/main/java/com/vroong/tcp/client/DisposableTcpClient.java
@@ -1,8 +1,9 @@
 package com.vroong.tcp.client;
 
+import com.vroong.tcp.TcpUtils;
+import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.nio.charset.Charset;
@@ -16,7 +17,7 @@ public class DisposableTcpClient extends AbstractTcpClient {
 
   private Socket socket;
   private OutputStream writer;
-  private BufferedReader reader;
+  private InputStream reader;
 
   public DisposableTcpClient(String host, int port, Charset charset) {
     this.host = host;
@@ -34,12 +35,12 @@ public class DisposableTcpClient extends AbstractTcpClient {
 
   @Override
   public byte[] read() throws Exception {
-    reader = new BufferedReader(new InputStreamReader(socket.getInputStream(), charset));
-    final String tmp = reader.readLine();
+    reader = new BufferedInputStream(socket.getInputStream());
+    final byte[] rawMessage = TcpUtils.readLine(reader);
 
     clearResources();
 
-    return (tmp != null) ? tmp.getBytes(charset) : new byte[]{};
+    return rawMessage;
   }
 
   private void clearResources() throws Exception {

--- a/src/main/java/com/vroong/tcp/client/DisposableTcpClient.java
+++ b/src/main/java/com/vroong/tcp/client/DisposableTcpClient.java
@@ -6,7 +6,6 @@ import java.io.BufferedOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
-import java.nio.charset.Charset;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -19,10 +18,9 @@ public class DisposableTcpClient extends AbstractTcpClient {
   private OutputStream writer;
   private InputStream reader;
 
-  public DisposableTcpClient(String host, int port, Charset charset) {
+  public DisposableTcpClient(String host, int port) {
     this.host = host;
     this.port = port;
-    this.charset = charset;
   }
 
   @Override

--- a/src/main/java/com/vroong/tcp/client/PooledTcpClient.java
+++ b/src/main/java/com/vroong/tcp/client/PooledTcpClient.java
@@ -6,7 +6,6 @@ import java.io.BufferedOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
-import java.nio.charset.Charset;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -28,7 +27,7 @@ public class PooledTcpClient extends AbstractTcpClient {
 
   private Tuple currentTuple;
 
-  public PooledTcpClient(String host, int port, Charset charset, int minIdle, int maxIdle, int maxTotal) {
+  public PooledTcpClient(String host, int port, int minIdle, int maxIdle, int maxTotal) {
 
     final GenericObjectPoolConfig<Tuple> config = new GenericObjectPoolConfig<>();
     // org.apache.commons.pool2.impl.GenericObjectPoolConfig.DEFAULT_MIN_IDLE = 0
@@ -75,8 +74,6 @@ public class PooledTcpClient extends AbstractTcpClient {
     } catch (Exception e) {
       log.error(String.format("Socket add failed: %s", e.getMessage()), e);
     }
-
-    this.charset = charset;
   }
 
   @Override

--- a/src/main/java/com/vroong/tcp/client/PooledTcpClient.java
+++ b/src/main/java/com/vroong/tcp/client/PooledTcpClient.java
@@ -1,8 +1,9 @@
 package com.vroong.tcp.client;
 
+import com.vroong.tcp.TcpUtils;
+import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.nio.charset.Charset;
@@ -28,6 +29,7 @@ public class PooledTcpClient extends AbstractTcpClient {
   private Tuple currentTuple;
 
   public PooledTcpClient(String host, int port, Charset charset, int minIdle, int maxIdle, int maxTotal) {
+
     final GenericObjectPoolConfig<Tuple> config = new GenericObjectPoolConfig<>();
     // org.apache.commons.pool2.impl.GenericObjectPoolConfig.DEFAULT_MIN_IDLE = 0
     config.setMinIdle(minIdle);
@@ -43,8 +45,7 @@ public class PooledTcpClient extends AbstractTcpClient {
       public Tuple create() throws Exception {
         final Socket socket = createSocket(host, port, connectionTimeout, readTimeout);
         final BufferedOutputStream writer = new BufferedOutputStream(socket.getOutputStream());
-        final BufferedReader reader = new BufferedReader(
-            new InputStreamReader(socket.getInputStream(), charset));
+        final BufferedInputStream reader = new BufferedInputStream(socket.getInputStream());
 
         return new Tuple(socket, writer, reader);
       }
@@ -91,12 +92,12 @@ public class PooledTcpClient extends AbstractTcpClient {
   @Override
   public byte[] read() throws Exception {
     System.out.println("reader: " + currentTuple.toString());
-    final BufferedReader reader = currentTuple.getReader();
-    final byte[] message = reader.readLine().getBytes(charset);
+    final InputStream reader = currentTuple.getReader();
+    final byte[] rawMessage = TcpUtils.readLine(reader);
 
     clearResources();
 
-    return message;
+    return rawMessage;
   }
 
   private void clearResources() throws Exception {
@@ -121,6 +122,6 @@ public class PooledTcpClient extends AbstractTcpClient {
 
     private Socket socket;
     private OutputStream writer;
-    private BufferedReader reader;
+    private InputStream reader;
   }
 }

--- a/src/main/java/com/vroong/tcp/config/TcpClientProperties.java
+++ b/src/main/java/com/vroong/tcp/config/TcpClientProperties.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 public class TcpClientProperties {
 
   final String host = "localhost";
-  final int port = 65535;
+  final int port = 65_535;
   final int connectionTimeout = 1_000; // millis
   final int readTimeout = 5_000; // millis
   @Getter(AccessLevel.NONE)

--- a/src/main/java/com/vroong/tcp/server/AbstractTcpServer.java
+++ b/src/main/java/com/vroong/tcp/server/AbstractTcpServer.java
@@ -66,11 +66,11 @@ public abstract class AbstractTcpServer {
   @SneakyThrows
   public void stop() {
     if (socketHolder != null) {
-      socketHolder.get().forEach(s -> {
+      socketHolder.get().forEach(socket -> {
         try {
-          s.close();
+          socket.close();
         } catch (IOException e) {
-          log.error(String.format("Connection to port %s was not closed", s.getPort()));
+          log.error(String.format("Connection to port %s was not closed", socket.getPort()));
         }
       });
     }

--- a/src/main/java/com/vroong/tcp/server/AbstractTcpServer.java
+++ b/src/main/java/com/vroong/tcp/server/AbstractTcpServer.java
@@ -1,10 +1,11 @@
 package com.vroong.tcp.server;
 
 import com.vroong.tcp.config.TcpServerProperties;
-import java.io.BufferedReader;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.PrintWriter;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.ArrayList;
@@ -31,7 +32,7 @@ public abstract class AbstractTcpServer {
     this.executor = Executors.newFixedThreadPool(properties.getMaxConnection());
   }
 
-  public abstract void handleMessage(BufferedReader reader, PrintWriter writer);
+  public abstract void handleMessage(InputStream reader, OutputStream writer);
 
   @SneakyThrows
   public void start() {
@@ -45,8 +46,9 @@ public abstract class AbstractTcpServer {
       log.info("A connection established to port {}", socket.getPort());
 
       CompletableFuture.runAsync(() -> {
-        try (PrintWriter writer = new PrintWriter(socket.getOutputStream(), true);
-            BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
+        try (BufferedInputStream reader = new BufferedInputStream(socket.getInputStream());
+            BufferedOutputStream writer = new BufferedOutputStream(socket.getOutputStream())) {
+
           handleMessage(reader, writer);
         } catch (IOException e) {
           log.warn("{}: {}", e.getMessage(), socket.getPort());

--- a/src/main/java/com/vroong/tcp/server/AbstractTcpServer.java
+++ b/src/main/java/com/vroong/tcp/server/AbstractTcpServer.java
@@ -14,7 +14,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.annotation.PreDestroy;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
@@ -25,8 +24,7 @@ public abstract class AbstractTcpServer {
   protected final ExecutorService executor;
 
   protected final AtomicReference<ServerSocket> serverSocketHolder = new AtomicReference<>();
-  protected final AtomicReference<List<Socket>> socketHolder = new AtomicReference<>(
-      new ArrayList<>());
+  protected final AtomicReference<List<Socket>> socketHolder = new AtomicReference<>(new ArrayList<>());
 
   public AbstractTcpServer(TcpServerProperties properties) {
     this.port = properties.getPort();
@@ -47,19 +45,13 @@ public abstract class AbstractTcpServer {
       log.info("A connection established to port {}", socket.getPort());
 
       CompletableFuture.runAsync(() -> {
-        PrintWriter writer = null;
-        BufferedReader reader = null;
-        try {
-          writer = new PrintWriter(socket.getOutputStream(), true);
-          reader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
-
+        try (PrintWriter writer = new PrintWriter(socket.getOutputStream(), true);
+            BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
           handleMessage(reader, writer);
         } catch (IOException e) {
           log.warn("{}: {}", e.getMessage(), socket.getPort());
         } finally {
           try {
-            reader.close();
-            writer.close();
             socket.close();
           } catch (IOException e) {
             log.error(String.format("Connection to port %s was not closed", socket.getPort()));
@@ -69,7 +61,6 @@ public abstract class AbstractTcpServer {
     }
   }
 
-  @PreDestroy
   @SneakyThrows
   public void stop() {
     if (socketHolder != null) {

--- a/src/main/java/com/vroong/tcp/server/EchoServer.java
+++ b/src/main/java/com/vroong/tcp/server/EchoServer.java
@@ -1,8 +1,9 @@
 package com.vroong.tcp.server;
 
+import com.vroong.tcp.TcpUtils;
 import com.vroong.tcp.config.TcpServerProperties;
-import java.io.BufferedReader;
-import java.io.PrintWriter;
+import java.io.InputStream;
+import java.io.OutputStream;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
@@ -13,12 +14,16 @@ public class EchoServer extends AbstractTcpServer {
     super(properties);
   }
 
+  public static void main(String[] args) {
+    new EchoServer(new TcpServerProperties()).start();
+  }
+
   @SneakyThrows
   @Override
-  public void handleMessage(BufferedReader reader, PrintWriter writer) {
-    String message;
-    while ((message = reader.readLine()) != null) {
-      writer.println(message);
-    }
+  public void handleMessage(InputStream reader, OutputStream writer) {
+    final byte[] buffer = TcpUtils.readLine(reader);
+
+    writer.write(buffer);
+    writer.flush();
   }
 }

--- a/src/main/java/com/vroong/tcp/server/example/EchoServer.java
+++ b/src/main/java/com/vroong/tcp/server/example/EchoServer.java
@@ -1,7 +1,8 @@
-package com.vroong.tcp.server;
+package com.vroong.tcp.server.example;
 
 import com.vroong.tcp.TcpUtils;
 import com.vroong.tcp.config.TcpServerProperties;
+import com.vroong.tcp.server.AbstractTcpServer;
 import java.io.InputStream;
 import java.io.OutputStream;
 import lombok.SneakyThrows;

--- a/src/main/java/com/vroong/tcp/tcpExample/FixedByteFormatter.java
+++ b/src/main/java/com/vroong/tcp/tcpExample/FixedByteFormatter.java
@@ -26,7 +26,7 @@ public class FixedByteFormatter implements Formatter {
 
   private String doFormat(List<TcpMessage> components) {
     final StringBuilder formatted = new StringBuilder();
-    components.stream()
+    components
         .forEach(component -> {
           String fragment = "";
           if (component instanceof Item) {

--- a/src/main/java/com/vroong/tcp/visitor/Parseable.java
+++ b/src/main/java/com/vroong/tcp/visitor/Parseable.java
@@ -1,6 +1,6 @@
 package com.vroong.tcp.visitor;
 
-public interface Parceable {
+public interface Parseable {
 
   void accept(Parser parser);
 }

--- a/src/main/java/com/vroong/tcp/visitor/example/FixedByteFormatter.java
+++ b/src/main/java/com/vroong/tcp/visitor/example/FixedByteFormatter.java
@@ -1,4 +1,4 @@
-package com.vroong.tcp.tcpExample;
+package com.vroong.tcp.visitor.example;
 
 import com.vroong.tcp.Item;
 import com.vroong.tcp.Packet;

--- a/src/main/java/com/vroong/tcp/visitor/example/FixedByteParser.java
+++ b/src/main/java/com/vroong/tcp/visitor/example/FixedByteParser.java
@@ -1,4 +1,4 @@
-package com.vroong.tcp.tcpExample;
+package com.vroong.tcp.visitor.example;
 
 import com.vroong.tcp.Item;
 import com.vroong.tcp.Packet;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,13 +2,11 @@ tcp:
   server:
     port: 65535
     max-connection: 100
-    charset: utf-8
   client:
     host: localhost
     port: ${tcp.server.port}
     connection-timeout: 1000 # millis
     read-timeout: 5000 # millis
-    charset: ${tcp.server.charset}
     pool:
       min-idle: 10
       max-idle: 10

--- a/src/test/java/com/vroong/tcp/TcpUtilsTest.java
+++ b/src/test/java/com/vroong/tcp/TcpUtilsTest.java
@@ -1,0 +1,40 @@
+package com.vroong.tcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+class TcpUtilsTest {
+
+  @ParameterizedTest
+  @ArgumentsSource(ByteArrayProvider.class)
+  void containsNewLine(byte[] vector, boolean expected) {
+    assertEquals(expected, TcpUtils.containsNewLine(vector));
+  }
+
+  static class ByteArrayProvider implements ArgumentsProvider {
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+      return Stream.of(
+          Arguments.of("안녕하세요".getBytes(), false),
+          Arguments.of("안녕하세요".getBytes("utf-8"), false),
+          Arguments.of("안녕하세요".getBytes("cp949"), false),
+          Arguments.of("안녕하세요".getBytes("euc-kr"), false),
+          Arguments.of("안녕하세요\n".getBytes(), true),
+          Arguments.of("안녕하세요\n".getBytes("utf-8"), true),
+          Arguments.of("안녕하세요\n".getBytes("cp949"), true),
+          Arguments.of("안녕하세요\n".getBytes("euc-kr"), true),
+          Arguments.of("안녕하세요\n 안녕하세요".getBytes(), true),
+          Arguments.of("안녕하세요\n 안녕하세요".getBytes("utf-8"), true),
+          Arguments.of("안녕하세요\n 안녕하세요".getBytes("cp949"), true),
+          Arguments.of("안녕하세요\n 안녕하세요".getBytes("euc-kr"), true)
+      );
+    }
+  }
+}

--- a/src/test/java/com/vroong/tcp/client/TcpClientTest.java
+++ b/src/test/java/com/vroong/tcp/client/TcpClientTest.java
@@ -27,8 +27,7 @@ class TcpClientTest {
 
   @Test
   void disposableTcpClient() throws Exception {
-    final TcpClient client = new DisposableTcpClient(properties.getHost(), properties.getPort(),
-        properties.getCharset());
+    final TcpClient client = new DisposableTcpClient(properties.getHost(), properties.getPort());
 
     final String message = "안녕하세요?\n";
     client.write(message.getBytes(properties.getCharset()));
@@ -40,7 +39,7 @@ class TcpClientTest {
   @Test
   void pooledTcpClient() throws Exception {
     final TcpClient client = new PooledTcpClient(properties.getHost(), properties.getPort(),
-        properties.getCharset(), poolConfig.getMinIdle(), poolConfig.getMaxIdle(), poolConfig.getMaxTotal());
+        poolConfig.getMinIdle(), poolConfig.getMaxIdle(), poolConfig.getMaxTotal());
 
     final ObjectPool<Tuple> pool = getPool(client);
     assertEquals(poolConfig.getMinIdle(), pool.getNumIdle());
@@ -62,7 +61,7 @@ class TcpClientTest {
     // spring-data-redis 등도 apache.commons.pool2를 사용함
   void pooledTcpClient_underMultiThreads() {
     final TcpClient client = new PooledTcpClient(properties.getHost(), properties.getPort(),
-        properties.getCharset(), poolConfig.getMinIdle(), poolConfig.getMaxIdle(), poolConfig.getMaxTotal());
+        poolConfig.getMinIdle(), poolConfig.getMaxIdle(), poolConfig.getMaxTotal());
     final ObjectPool<Tuple> pool = getPool(client);
     final int noOfTests = poolConfig.getMaxTotal();
     final Executor executor = Executors.newFixedThreadPool(noOfTests);

--- a/src/test/java/com/vroong/tcp/client/TcpClientTest.java
+++ b/src/test/java/com/vroong/tcp/client/TcpClientTest.java
@@ -40,8 +40,7 @@ class TcpClientTest {
   @Test
   void pooledTcpClient() throws Exception {
     final TcpClient client = new PooledTcpClient(properties.getHost(), properties.getPort(),
-        properties.getCharset(), poolConfig.getMinIdle(), poolConfig.getMaxIdle(),
-        poolConfig.getMaxTotal());
+        properties.getCharset(), poolConfig.getMinIdle(), poolConfig.getMaxIdle(), poolConfig.getMaxTotal());
 
     final ObjectPool<Tuple> pool = getPool(client);
     assertEquals(poolConfig.getMinIdle(), pool.getNumIdle());
@@ -63,8 +62,7 @@ class TcpClientTest {
     // spring-data-redis 등도 apache.commons.pool2를 사용함
   void pooledTcpClient_underMultiThreads() {
     final TcpClient client = new PooledTcpClient(properties.getHost(), properties.getPort(),
-        properties.getCharset(), poolConfig.getMinIdle(), poolConfig.getMaxIdle(),
-        poolConfig.getMaxTotal());
+        properties.getCharset(), poolConfig.getMinIdle(), poolConfig.getMaxIdle(), poolConfig.getMaxTotal());
     final ObjectPool<Tuple> pool = getPool(client);
     final int noOfTests = poolConfig.getMaxTotal();
     final Executor executor = Executors.newFixedThreadPool(noOfTests);
@@ -94,11 +92,12 @@ class TcpClientTest {
       }
     }
 
-    futures.stream().forEach(f -> {
-      try {
-        log.info("response: {}", new String(f.get(), properties.getCharset()));
-      } catch (Exception e) {
-      }
+    futures
+      .forEach(f -> {
+        try {
+          log.info("response: {}", new String(f.get(), properties.getCharset()));
+        } catch (Exception ignored) {
+        }
     });
 
     log.info("All done, pool state: numIdle={}, numActive={}", pool.getNumIdle(), pool.getNumActive());

--- a/src/test/java/com/vroong/tcp/visitor/example/FixedByteFormatterTest.java
+++ b/src/test/java/com/vroong/tcp/visitor/example/FixedByteFormatterTest.java
@@ -1,4 +1,4 @@
-package com.vroong.tcp.tcpExample;
+package com.vroong.tcp.visitor.example;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/src/test/java/com/vroong/tcp/visitor/example/FixedByteParserTest.java
+++ b/src/test/java/com/vroong/tcp/visitor/example/FixedByteParserTest.java
@@ -1,4 +1,4 @@
-package com.vroong.tcp.tcpExample;
+package com.vroong.tcp.visitor.example;
 
 import com.vroong.tcp.Item;
 import com.vroong.tcp.Packet;


### PR DESCRIPTION
## Description
- 코드 및 UML을 제 스타일로 변경했습니다.
- TcpClient 및 EchoServer에서 readLine()을 직접 구현했습니다
## Modification
### 코드 및 UML 수정
- number 타입 표기 일관성: final int port = 65535 -> 65_535
- 인터페이스 이름 변경: parceable -> parseable
- stream().foreach() -> foreach()
- try with resource 적용
- docs/tcp-client.puml 수정
### socket에서 InputStream read 구현 변경
- readLine() -> read() 구현
- return type: String -> byte[]