### PR TITLE
readme.md: dependencies 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ vroong-tcplibrary는 TCP 서버 또는 클라이언트를 쉽게 구현하기 �
 
 ### Dependencies
 - Java 8 or higher
+- Gradle 6.0 or higher
 
 ### Installation
 


### PR DESCRIPTION
gradle 6.0 미만 버전에서는 vroongtcp-spring-boot-autoconfigure가 external libraries에 추가되지 않는 것 확인해서 readme 수정했습니다.

참고차 pr 올립니다.