### PR TITLE
Fix socket exception when server stops

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ allprojects {
     apply plugin: 'idea'
 
     group = 'com.vroong'
-    version = '2.0.2-RELEASE'
+    version = '2.0.3-RELEASE'
 
     repositories {
         mavenCentral()

--- a/tcplibrary/src/main/java/com/vroong/tcp/server/AbstractTcpServer.java
+++ b/tcplibrary/src/main/java/com/vroong/tcp/server/AbstractTcpServer.java
@@ -8,6 +8,7 @@ import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -83,7 +84,16 @@ public abstract class AbstractTcpServer implements TcpServer {
     log.info("Tcp server is listening at port {}", port);
 
     while (true) {
-      final Socket socket = serverSocket.accept(); // 여기서 블록킹하고 있다가, 클라이언트가 접속하면 해제됨
+      Socket acceptedScoket = null;
+      try {
+        acceptedScoket = serverSocket.accept(); // 여기서 블록킹하고 있다가, 클라이언트가 접속하면 해제됨
+      } catch (SocketException ignored) {
+        // When closing the ServerSocket, the blocking thread will throw a SocketException.
+        // https://docs.oracle.com/javase/7/docs/api/java/net/ServerSocket.html#close()
+        return;
+      }
+
+      final Socket socket = acceptedScoket;
       socketHolder.get().add(socket);
       log.info("A connection established to port {}", socket.getPort());
 

--- a/tcplibrary/src/main/java/com/vroong/tcp/server/AbstractTcpServer.java
+++ b/tcplibrary/src/main/java/com/vroong/tcp/server/AbstractTcpServer.java
@@ -95,7 +95,7 @@ public abstract class AbstractTcpServer implements TcpServer {
 
       final Socket socket = acceptedScoket;
       socketHolder.get().add(socket);
-      log.info("A connection established to port {}", socket.getPort());
+      log.info("A connection established with {}", socket.getRemoteSocketAddress());
 
       CompletableFuture.runAsync(() -> {
         try {
@@ -115,6 +115,7 @@ public abstract class AbstractTcpServer implements TcpServer {
           // TODO: 클라이언트가 PooledTcpClient를 사용할 경우에 대한 처리 필요
           try {
             socket.close();
+            log.info("A connection with {} is closed", socket.getRemoteSocketAddress());
           } catch (IOException e) {
             log.error(String.format("Connection to port %s was not closed", socket.getPort()));
           }


### PR DESCRIPTION
ServerSocket을 close할 경우, ServerSocket.accept()에서 SocketException이 발생하는 것을 처리했습니다.
master에 머지되면 태그 후 publish하고, pointchargercallback에 적용하겠습니다.